### PR TITLE
Fix: fill doesn't work on img tag

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -19,7 +19,7 @@ function Footer() {
         </div>
         <div className='footer-socials'>
         <a title='Discord' href={config.discordInviteURL} target="_blank" rel='noreferrer'>
-            <IconDiscord alt="Discord" className='social-icon' />
+            <IconDiscord alt='Discord' className='social-icon' />
           </a>
           <a title='Twitter' href="https://twitter.com/cmty_architects" target="_blank" rel='noreferrer'>
             <IconTwitter alt='Twitter' className='social-icon' />

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,12 +1,7 @@
 import config from '../config.json';
 import { Logo } from './Symbols';
 import { Link } from 'react-router-dom';
-
-import DiscordIcon from '../assets/social-icons/discord.svg';
-import TwitterIcon from '../assets/social-icons/twitter.svg';
-import GitHubIcon from '../assets/social-icons/github.svg';
-import YouTubeIcon from '../assets/social-icons/youtube.svg';
-import LinkedInIcon from '../assets/social-icons/linkedin.svg';
+import { IconDiscord, IconTwitter, IconGitHub, IconYouTube, IconLinkedIn } from "./Symbols";
 
 function Footer() {
   return (
@@ -23,24 +18,24 @@ function Footer() {
           </div>
         </div>
         <div className='footer-socials'>
-          <a title='Discord' href={config.discordInviteURL} target="_blank" rel='noreferrer'>
-            <img alt='Discord' src={DiscordIcon} className='social-icon' />
+        <a title='Discord' href={config.discordInviteURL} target="_blank" rel='noreferrer'>
+            <IconDiscord alt="Discord" className='social-icon' />
           </a>
           <a title='Twitter' href="https://twitter.com/cmty_architects" target="_blank" rel='noreferrer'>
-            <img alt='Twitter' src={TwitterIcon} className='social-icon' />
+            <IconTwitter alt='Twitter' className='social-icon' />
           </a>
           <a title='GitHub' href="https://github.com/communityarchitects" target="_blank" rel='noreferrer'>
-            <img alt='GitHub' src={GitHubIcon} className='social-icon' />
+            <IconGitHub alt='GitHub' className='social-icon' />
           </a>
           <a title='YouTube' href="https://www.youtube.com/@cmty_architects" target="_blank" rel='noreferrer'>
-            <img alt='YouTube' src={YouTubeIcon} className='social-icon' />
+            <IconYouTube alt='YouTube' className='social-icon' />
           </a>
           <a title='LinkedIn' href="https://www.linkedin.com/company/communityarchitects/" target="_blank" rel='noreferrer'>
-            <img alt='LinkedIn' src={LinkedInIcon} className='social-icon' />
+            <IconLinkedIn alt='LinkedIn' className='social-icon' />
           </a>
         </div>
-      </footer >
-    </div >
+      </footer>
+    </div>
   );
 }
 

--- a/src/components/Symbols.jsx
+++ b/src/components/Symbols.jsx
@@ -12,3 +12,8 @@ export { ReactComponent as Arrow } from '../assets/symbols/arrow.svg';
 export { ReactComponent as Logo } from '../assets/symbols/logo.svg';
 export { ReactComponent as IconModerator } from '../assets/symbols/role-moderator.svg';
 export { ReactComponent as IconProfessional } from '../assets/symbols/role-professional.svg';
+export { ReactComponent as IconDiscord } from '../assets/social-icons/discord.svg';
+export { ReactComponent as IconTwitter } from '../assets/social-icons/twitter.svg';
+export { ReactComponent as IconGitHub } from '../assets/social-icons/github.svg';
+export { ReactComponent as IconYouTube } from '../assets/social-icons/youtube.svg';
+export { ReactComponent as IconLinkedIn } from '../assets/social-icons/linkedin.svg';


### PR DESCRIPTION
During the change to Vite I used `<img>` tags for svg icons forgetting about the fill style, I moved them to the symbols store and import them as `ReactComponent` which makes them currently behave correctly. 